### PR TITLE
INTER-2051: Add SDK version support and EOL table to README

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -200,6 +200,13 @@ See the full [API reference](https://fingerprintjs.github.io/node-sdk/).
 * It is highly recommended that you lock your package version to a specific PATCH release and upgrade with the expectation that types may be upgraded between any release.
 * The runtime (non-type-related) public API of the Node SDK still follows semver strictly.
 
+## Version support
+
+| SDK major version | Server API version | Status | End of support |
+|---|---|---|---|
+| v7.x (current) | [v4](https://docs.fingerprint.com/reference/server-api) | Supported | - |
+| v1.x-v6.x | [v3](https://docs.fingerprint.com/reference/v3/server-api) | Deprecated (security fixes only). See the [migration guide](https://docs.fingerprint.com/reference/node-server-sdk#migration-guide-for-node-sdk-v7). | To be decided |
+
 ## Support and feedback
 
 To report problems, ask questions, or provide feedback, please use [Issues](https://github.com/fingerprintjs/node-sdk/issues). If you need private support, you can email us at [oss-support@fingerprint.com](mailto:oss-support@fingerprint.com).


### PR DESCRIPTION
This PR addresses concerns raised in [INTER-2051](https://fingerprintjs.atlassian.net/browse/INTER-2051). This is one PR as a part of a thread of PRs that will need to be made for each SDK.

Adds a "Version support" section to the README with a single table showing which SDK major versions map to which Server API version, their current status, and end-of-support info.

https://github.com/fingerprintjs/node-sdk/pull/275 was created as a proof of concept for when we initially did work for the go-sdk. If this is approved, will plan to close PR #275 

[INTER-2051]: https://fingerprintjs.atlassian.net/browse/INTER-2051?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ